### PR TITLE
Exclude generated icon file from coverage

### DIFF
--- a/lib/src/utils/flutter_class_gen.dart
+++ b/lib/src/utils/flutter_class_gen.dart
@@ -136,6 +136,7 @@ class FlutterClassGenerator {
 // Generated using $kVendorName.
 // Copyright © ${DateTime.now().year} $kVendorName ($kVendorUrl).
 
+// coverage:ignore-file
 import 'package:flutter/widgets.dart';
 
 /// Identifiers for the icons.


### PR DESCRIPTION
This generated file is part of a (Flutter) project. However, the private constructor can't be tested. So projects using this can't aim for 100% coverage. With this line you can ignore this complete file from the test coverage. 
We could also use 
```
// coverage:ignore-line to ignore one line.
// coverage:ignore-start and // coverage:ignore-end to ignore range of lines inclusive.
```