### PR TITLE
feat!: bump dependencies

### DIFF
--- a/bin/fontify.dart
+++ b/bin/fontify.dart
@@ -42,17 +42,17 @@ void _run(CliArguments parsedArgs) {
   final isVerbose = parsedArgs.verbose ?? kDefaultVerbose;
 
   if (isVerbose) {
-    logger.setFilterLevel(Level.verbose);
+    logger.setFilterLevel(Level.trace);
   }
 
   if (parsedArgs.classFile?.existsSync() ?? false) {
-    logger.v(
+    logger.t(
         'Output file for a Flutter class already exists (${parsedArgs.classFile!.path}) - '
         'overwriting it');
   }
 
   if (!parsedArgs.fontFile.existsSync()) {
-    logger.v(
+    logger.t(
         'Output file for a font file already exists (${parsedArgs.fontFile.path}) - '
         'overwriting it');
   }
@@ -82,7 +82,7 @@ void _run(CliArguments parsedArgs) {
   writeToFile(parsedArgs.fontFile.path, otfResult.font);
 
   if (parsedArgs.classFile == null) {
-    logger.v('No output path for Flutter class was specified - '
+    logger.t('No output path for Flutter class was specified - '
         'skipping class generation.');
   } else {
     final fontFileName = p.basename(parsedArgs.fontFile.path);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,13 +11,13 @@ environment:
 dependencies:
   args: ^2.0.0
   collection: ^1.15.0
-  logger: ^1.0.0
+  logger: ^2.0.0
   meta: ^1.3.0
   path: ^1.8.0
-  path_parsing: ^0.2.0
+  path_parsing: ^1.0.0
   recase: ^4.0.0
   vector_math: ^2.1.0
-  xml: ^5.1.0
+  xml: ^6.0.0
   yaml: ^3.1.0
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ description: >-
 homepage: https://github.com/westracer/fontify
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
   args: ^2.0.0


### PR DESCRIPTION
A couple of dependencies are outdated, and is causing dependency resolution issues.

This PR:

- bumps `logger`, `path_parsing` and `xml` to their next major version
- addresses `logger` deprecation warnings